### PR TITLE
Fix Select module to use both inputs

### DIFF
--- a/src/LibNoise.NET35/Selector/Select.cs
+++ b/src/LibNoise.NET35/Selector/Select.cs
@@ -253,7 +253,7 @@ namespace LibNoise.Modifier
 
                     return Libnoise.Lerp(
                         ((IModule3D) _leftModule).GetValue(x, y, z),
-                        ((IModule3D) _leftModule).GetValue(x, y, z),
+                        ((IModule3D) _rightModule).GetValue(x, y, z),
                         alpha
                         );
                 }
@@ -261,7 +261,7 @@ namespace LibNoise.Modifier
                 {
                     // The output value from the control module is within the selector
                     // threshold; return the output value from the second source module.
-                    return ((IModule3D) _leftModule).GetValue(x, y, z);
+                    return ((IModule3D) _rightModule).GetValue(x, y, z);
                 }
                 else if (controlValue < (_upperBound + _edgeFalloff))
                 {
@@ -276,7 +276,7 @@ namespace LibNoise.Modifier
                         );
 
                     return Libnoise.Lerp(
-                        ((IModule3D) _leftModule).GetValue(x, y, z),
+                        ((IModule3D) _rightModule).GetValue(x, y, z),
                         ((IModule3D) _leftModule).GetValue(x, y, z),
                         alpha
                         );
@@ -293,7 +293,7 @@ namespace LibNoise.Modifier
                 if (controlValue < _lowerBound || controlValue > _upperBound)
                     return ((IModule3D) _leftModule).GetValue(x, y, z);
                 else
-                    return ((IModule3D) _leftModule).GetValue(x, y, z);
+                    return ((IModule3D) _rightModule).GetValue(x, y, z);
             }
         }
 


### PR DESCRIPTION
### Summary
The Select module currently always outputs the value of its `leftModule`. This pull request contains changes to the module that fix this behaviour. The changes are based on the original library code.

Corresponding lines in [original code](http://libnoise.cvs.sourceforge.net/viewvc/libnoise/noise/src/module/select.cpp?view=markup) are 59, 65, 75 and 88. Basically, all references equivalent to `m_pSourceModule[1]` in original code have been updated to use `_rightModule` instead of `_leftModule` in the ported code.

### Reproduce the problem
A quick way to reproduce the problem is to replace line 376 in `FrmMain.cs` with the following:
```csharp
projection.SourceModule = new Select(new Cylinders(2), finalModule, new Constant(), 0.1f, 0.9f, 0.0f);
```

The input the Select module gets is as follows:
Control module:
![img-control](https://cloud.githubusercontent.com/assets/5447834/23333458/c7911536-fb8b-11e6-8458-a5ad87b45def.png)
Left Module and Right module:
![img-left](https://cloud.githubusercontent.com/assets/5447834/23333460/cae42e4e-fb8b-11e6-8797-ec6fdf041fa8.png) ![img-right](https://cloud.githubusercontent.com/assets/5447834/23333461/cd621640-fb8b-11e6-8e33-df4301f8156b.png)

In the current version (changes from pull request not applied) this results in following image:
![img-result-before](https://cloud.githubusercontent.com/assets/5447834/23333481/4c52280a-fb8c-11e6-89d1-ad3f76ac8ff9.png)
This is obviously just a direct copy of the left module and not a select operation applied.

With the changes applied the results look like this:
Left with edgeFalloff set to 0, right set to 0.5
![img-result-after](https://cloud.githubusercontent.com/assets/5447834/23333543/7f591474-fb8d-11e6-8460-1184b53b12fb.png) ![img-result-after-fo05](https://cloud.githubusercontent.com/assets/5447834/23333546/8309f930-fb8d-11e6-8436-c636f9d97cb7.png)

The behaviour after the patch has been applied corresponds to what is written in the code comments for the `Select` module.